### PR TITLE
Update for compatibility with Serial via Bluetooth

### DIFF
--- a/Rocco.ino
+++ b/Rocco.ino
@@ -40,7 +40,7 @@ void setup()
   //int angle[18] = {90,90,90,90,90,90,90,90,90,90,90,90,90,90,90,90,90,90};
   //Serial.begin(9600);  //create serial object
   delay(500);
-  Serial.begin(19200);
+  Serial.begin(9600);
   delay(500);
   //attach servos to pins
   servo[0].attach(2);


### PR DESCRIPTION
I thought further changes would be required, but the only change needed
to get serial working over Bluetooth using HC-06 Serial-Bluetooth for
Arduino was the baud rate.  I had it on 19200 and have changed it to
9600 to match the hardware BT module.
